### PR TITLE
FNA port works!

### DIFF
--- a/BEPUphysics/BEPUphysics.FNA.csproj
+++ b/BEPUphysics/BEPUphysics.FNA.csproj
@@ -2,7 +2,6 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{2A9D2227-78D7-4804-B6D1-560BB43AE911}</ProjectGuid>
-    <ProjectTypeGuids>{6D335F3A-9D43-41b4-9D22-F6F17C4BE596};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
     <OutputType>Library</OutputType>
@@ -11,11 +10,6 @@
     <AssemblyName>BEPUphysics</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <TargetFrameworkProfile>Client</TargetFrameworkProfile>
-    <XnaFrameworkVersion>v4.0</XnaFrameworkVersion>
-    <XnaPlatform>Windows</XnaPlatform>
-    <XnaProfile>HiDef</XnaProfile>
-    <XnaCrossPlatformGroupID>7370a280-2dc9-49be-8ea9-7b6a817e142c</XnaCrossPlatformGroupID>
-    <XnaOutputType>Library</XnaOutputType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>
@@ -28,7 +22,6 @@
     <NoStdLib>true</NoStdLib>
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <PlatformTarget>x86</PlatformTarget>
-    <XnaCompressContent>false</XnaCompressContent>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
@@ -41,7 +34,6 @@
     <NoStdLib>true</NoStdLib>
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <PlatformTarget>x86</PlatformTarget>
-    <XnaCompressContent>true</XnaCompressContent>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DocumentationFile>bin\x86\Release\BEPUphysics.XML</DocumentationFile>
     <DebugSymbols>true</DebugSymbols>
@@ -420,7 +412,7 @@
     <None Include="strongNameKey.snk" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\BEPUutilities\BEPUutilities.csproj">
+    <ProjectReference Include="..\BEPUutilities\BEPUutilities.FNA.csproj">
       <Project>{E3AAEB61-D7DF-4E7E-A75B-B5282D2FF3F5}</Project>
       <Name>BEPUutilities</Name>
     </ProjectReference>
@@ -430,7 +422,6 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(MSBuildExtensionsPath)\Microsoft\XNA Game Studio\Microsoft.Xna.GameStudio.targets" />
   <!--
       To modify your build process, add your task inside one of the targets below and uncomment it. 
       Other similar extension points exist, see Microsoft.Common.targets.

--- a/BEPUutilities/BEPUutilities.FNA.csproj
+++ b/BEPUutilities/BEPUutilities.FNA.csproj
@@ -2,7 +2,6 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{E3AAEB61-D7DF-4E7E-A75B-B5282D2FF3F5}</ProjectGuid>
-    <ProjectTypeGuids>{6D335F3A-9D43-41b4-9D22-F6F17C4BE596};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
     <OutputType>Library</OutputType>
@@ -11,11 +10,6 @@
     <AssemblyName>BEPUutilities</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <TargetFrameworkProfile>Client</TargetFrameworkProfile>
-    <XnaFrameworkVersion>v4.0</XnaFrameworkVersion>
-    <XnaPlatform>Windows</XnaPlatform>
-    <XnaProfile>Reach</XnaProfile>
-    <XnaCrossPlatformGroupID>0aedf39e-8385-4a55-9db6-916f6d31ad51</XnaCrossPlatformGroupID>
-    <XnaOutputType>Library</XnaOutputType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>
@@ -28,7 +22,6 @@
     <NoStdLib>true</NoStdLib>
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <PlatformTarget>x86</PlatformTarget>
-    <XnaCompressContent>false</XnaCompressContent>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DocumentationFile>bin\x86\Debug\BEPUutilities.XML</DocumentationFile>
   </PropertyGroup>
@@ -42,7 +35,6 @@
     <NoStdLib>true</NoStdLib>
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <PlatformTarget>x86</PlatformTarget>
-    <XnaCompressContent>true</XnaCompressContent>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DocumentationFile>bin\x86\Release\BEPUutilities.XML</DocumentationFile>
   </PropertyGroup>
@@ -107,7 +99,6 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(MSBuildExtensionsPath)\Microsoft\XNA Game Studio\Microsoft.Xna.GameStudio.targets" />
   <!--
       To modify your build process, add your task inside one of the targets below and uncomment it. 
       Other similar extension points exist, see Microsoft.Common.targets.

--- a/Lemma/Components/Analytics.cs
+++ b/Lemma/Components/Analytics.cs
@@ -406,7 +406,11 @@ namespace Lemma.Components
 				this.workThread.Start();
 
 #if WINDOWS
+#if FNA
+				this.data.Memory = SDL2.SDL.SDL_GetSystemRAM();
+#else
 				this.data.Memory = (int)(new Microsoft.VisualBasic.Devices.ComputerInfo().TotalPhysicalMemory / (ulong)1048576);
+#endif
 				ManagementObject cpu = new ManagementObjectSearcher("select * from Win32_Processor").Get().Cast<ManagementObject>().First();
 				this.data.CPU = string.Format("{0} {1}", cpu["Name"], cpu["Caption"]);
 				ManagementObjectSearcher searcher = new ManagementObjectSearcher("select * from Win32_DisplayConfiguration");

--- a/Lemma/Components/TimeTrialUI.cs
+++ b/Lemma/Components/TimeTrialUI.cs
@@ -348,7 +348,7 @@ namespace Lemma.Components
 		{
 			Container container = this.main.UIFactory.CreateButton(delegate()
 			{
-				if (SteamWorker.SteamInitialized)
+				if (Util.SteamWorker.SteamInitialized)
 					SteamFriends.ActivateGameOverlayToUser("steamid", entry.m_steamIDUser);
 			});
 			this.resizeContainer(container, 4.0f);

--- a/Lemma/Factories/EditorFactory.cs
+++ b/Lemma/Factories/EditorFactory.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Windows.Forms;
 using ComponentBind;
 using System.Collections.Generic;
 using System.Linq;

--- a/Lemma/GeeUI/Views/TextFieldView.cs
+++ b/Lemma/GeeUI/Views/TextFieldView.cs
@@ -1,7 +1,6 @@
 ﻿
 using System;
 using System.Text.RegularExpressions;
-using System.Windows.Forms;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using GeeUI.Structs;
@@ -223,8 +222,11 @@ namespace GeeUI.Views
 						break;
 
 					case Keys.V:
-						// TODO: FNA clipboard
-						string text = Clipboard.GetText();
+#if FNA
+						string text = SDL2.SDL.SDL_GetClipboardText();
+#else
+						string text = System.Windows.Forms.Clipboard.GetText();
+#endif
 						if (!String.IsNullOrEmpty(text))
 							AppendTextCursor(text);
 						break;

--- a/Lemma/Lemma.FNA.csproj
+++ b/Lemma/Lemma.FNA.csproj
@@ -2,31 +2,16 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <PropertyGroup>
     <ProjectGuid>{3D2D163E-393B-4AFD-997B-143E909AC653}</ProjectGuid>
-    <ProjectTypeGuids>{6D335F3A-9D43-41b4-9D22-F6F17C4BE596};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
     <OutputType>WinExe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Lemma</RootNamespace>
     <AssemblyName>Lemma</AssemblyName>
-    <XnaFrameworkVersion>v4.0</XnaFrameworkVersion>
-    <XnaPlatform>Windows</XnaPlatform>
-    <XnaCrossPlatformGroupID>557ce702-14e8-4a52-b689-5977223a2d2b</XnaCrossPlatformGroupID>
     <ApplicationIcon>icon.ico</ApplicationIcon>
-    <Thumbnail>
-    </Thumbnail>
-    <XnaUpgrade>
-    </XnaUpgrade>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <FileUpgradeFlags>
-    </FileUpgradeFlags>
-    <OldToolsVersion>3.5</OldToolsVersion>
-    <UpgradeBackupLocation>
-    </UpgradeBackupLocation>
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <TargetFrameworkProfile>Client</TargetFrameworkProfile>
-    <XnaOutputType>Game</XnaOutputType>
-    <XnaProfile>HiDef</XnaProfile>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>
@@ -47,7 +32,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\x86\Debug</OutputPath>
-    <DefineConstants>TRACE;DEBUG;WINDOWS;DEVELOPMENT;VR</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;WINDOWS;DEVELOPMENT;VR;FNA</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <NoStdLib>true</NoStdLib>
@@ -59,20 +44,19 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\x86\Release</OutputPath>
-    <DefineConstants>WINDOWS;ANALYTICS;STEAMWORKS;VR</DefineConstants>
+    <DefineConstants>WINDOWS;STEAMWORKS;VR;FNA</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <NoStdLib>true</NoStdLib>
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <PlatformTarget>x86</PlatformTarget>
-    <XnaCompressContent>True</XnaCompressContent>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DebugSymbols>true</DebugSymbols>
     <GenerateSerializationAssemblies>On</GenerateSerializationAssemblies>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Development|x86'">
     <OutputPath>bin\x86\Development\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;WINDOWS;ANALYTICS;CHEAT;STEAMWORKS;DEVELOPMENT</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;WINDOWS;ANALYTICS;CHEAT;STEAMWORKS;DEVELOPMENT;FNA</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Optimize>true</Optimize>
     <NoStdLib>true</NoStdLib>
@@ -80,7 +64,6 @@
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <XnaCompressContent>True</XnaCompressContent>
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
@@ -88,7 +71,6 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualBasic" />
     <Reference Include="mscorlib">
       <Private>False</Private>
     </Reference>
@@ -98,16 +80,9 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Management" />
-    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.XML" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="AdapterSelectorForm.cs">
-      <SubType>Form</SubType>
-    </Compile>
-    <Compile Include="AdapterSelectorForm.Designer.cs">
-      <DependentUpon>AdapterSelectorForm.cs</DependentUpon>
-    </Compile>
     <Compile Include="ComponentInterfaces.cs" />
     <Compile Include="Components\AI.cs" />
     <Compile Include="Components\Agent.cs" />
@@ -166,12 +141,6 @@
     <Compile Include="Components\TimeTrial.cs" />
     <Compile Include="Components\Turret.cs" />
     <Compile Include="Components\VoxelFill.cs" />
-    <Compile Include="ErrorForm.cs">
-      <SubType>Form</SubType>
-    </Compile>
-    <Compile Include="ErrorForm.Designer.cs">
-      <DependentUpon>ErrorForm.cs</DependentUpon>
-    </Compile>
     <Compile Include="Factories\BouncerFactory.cs" />
     <Compile Include="Factories\ConsoleCommandFactory.cs" />
     <Compile Include="Factories\AnimatedPropFactory.cs" />
@@ -408,12 +377,6 @@
     <Compile Include="Wwise_IDs.cs" />
   </ItemGroup>
   <ItemGroup>
-    <NestedContentProject Include="Content\Content.contentproj">
-      <Project>6d5dbc4b-1de9-47b2-92af-546c5d1e4268</Project>
-      <Visible>False</Visible>
-    </NestedContentProject>
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\BEPUphysics\BEPUphysics.FNA.csproj">
       <Project>{2a9d2227-78d7-4804-b6d1-560bb43ae911}</Project>
       <Name>BEPUphysics.FNA</Name>
@@ -454,48 +417,6 @@
       <Project>{b1452f01-704f-44cd-bab5-2a15f8e5c2f1}</Project>
       <Name>Wwise.FNA</Name>
     </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1 Client Profile</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.2.0">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 2.0 %28x86%29</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.3.0">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.0 %28x86%29</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5</ProductName>
-      <Install>true</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Windows.Installer.3.1">
-      <Visible>False</Visible>
-      <ProductName>Windows Installer 3.1</ProductName>
-      <Install>true</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Xna.Framework.3.0">
-      <Visible>False</Visible>
-      <ProductName>Microsoft XNA Framework Redistributable 3.0</ProductName>
-      <Install>true</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Xna.Framework.4.0">
-      <Visible>False</Visible>
-      <ProductName>Microsoft XNA Framework Redistributable 4.0</ProductName>
-      <Install>true</Install>
-    </BootstrapperPackage>
   </ItemGroup>
   <ItemGroup>
     <Content Include="attribution.txt">
@@ -543,12 +464,6 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="AdapterSelectorForm.resx">
-      <DependentUpon>AdapterSelectorForm.cs</DependentUpon>
-    </EmbeddedResource>
-    <EmbeddedResource Include="ErrorForm.resx">
-      <DependentUpon>ErrorForm.cs</DependentUpon>
-    </EmbeddedResource>
     <EmbeddedResource Include="GeeUI\Resource1.resx">
       <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>Resource11.Designer.cs</LastGenOutput>
@@ -559,7 +474,6 @@
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(MSBuildExtensionsPath)\Microsoft\XNA Game Studio\Microsoft.Xna.GameStudio.targets" Condition="" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Lemma/Main.cs
+++ b/Lemma/Main.cs
@@ -795,7 +795,7 @@ namespace Lemma
 			this.Settings.LevelIndexProperty.Value = this.Settings.LevelIndex;
 			new NotifyBinding(delegate() { this.Settings.GodMode = this.Settings.GodModeProperty; }, this.Settings.GodModeProperty);
 			new NotifyBinding(delegate() { this.Settings.LevelIndex = this.Settings.LevelIndexProperty; }, this.Settings.LevelIndexProperty);
-			
+
 			TextElement.BindableProperties.Add("Forward", this.Settings.Forward);
 			TextElement.BindableProperties.Add("Left", this.Settings.Left);
 			TextElement.BindableProperties.Add("Backward", this.Settings.Backward);
@@ -849,6 +849,14 @@ namespace Lemma
 				if (this.Settings.Fullscreen)
 					this.Graphics.ApplyChanges();
 			}, this.Settings.Vsync);
+
+#if FNA
+			this.Window.IsBorderlessEXT = this.Settings.Borderless;
+			new NotifyBinding(delegate()
+			{
+				this.Window.IsBorderlessEXT = !this.Settings.Fullscreen && this.Settings.Borderless;
+			}, this.Settings.Borderless);
+#endif
 
 #if VR
 			if (this.VR)
@@ -2166,16 +2174,18 @@ namespace Lemma
 			if (this.Renderer != null)
 				this.Renderer.ReallocateBuffers(this.ScreenSize);
 
+#if FNA
+			this.Window.IsBorderlessEXT = !fullscreen && borderless;
+#endif
 			if (!fullscreen || borderless)
 			{
-				// TODO: FNA borderless window
-				/*
+#if !FNA
 				System.Windows.Forms.Control control = System.Windows.Forms.Control.FromHandle(this.Window.Handle);
 				System.Windows.Forms.Form form = control.FindForm();
 				form.FormBorderStyle = fullscreen || borderless ? System.Windows.Forms.FormBorderStyle.None : System.Windows.Forms.FormBorderStyle.Sizable;
 				if (fullscreen && borderless)
 					form.Location = new System.Drawing.Point(0, 0);
-				*/
+#endif
 				this.resize = null;
 			}
 

--- a/Lemma/Program.cs
+++ b/Lemma/Program.cs
@@ -15,12 +15,15 @@ namespace Lemma
 	    [STAThread]
 		public static void Main(string[] args)
 		{
+#if !FNA
 			System.Windows.Forms.Application.EnableVisualStyles();
+#endif
 #if VR
 			bool vr = args.Select(x => x.ToLower()).Contains("-vr");
 #endif
 
 			int monitor = 0;
+#if !FNA // TODO: Multiple monitors are supported, but we need something other than a Form :| -flibit
 			if (GraphicsAdapter.Adapters.Count > 1)
 			{
 				AdapterSelectorForm selectorForm = new AdapterSelectorForm(vr);
@@ -31,6 +34,7 @@ namespace Lemma
 				vr = selectorForm.VR;
 				monitor = selectorForm.Monitor;
 			}
+#endif
 
 			Main main = null;
 			if (Debugger.IsAttached)
@@ -73,6 +77,9 @@ namespace Lemma
 				{
 					string uuid = main != null ? (main.Settings != null ? main.Settings.UUID : null) : null;
 					Lemma.Main.Config.RecordAnalytics analytics = main != null ? (main.Settings != null ? main.Settings.Analytics : Lemma.Main.Config.RecordAnalytics.Off) : Lemma.Main.Config.RecordAnalytics.Off;
+#if FNA // TODO: Error reporting -flibit
+					SDL2.SDL.SDL_ShowSimpleMessageBox(SDL2.SDL.SDL_MessageBoxFlags.SDL_MESSAGEBOX_ERROR, "CRASH", e.ToString(), IntPtr.Zero);
+#else
 					ErrorForm errorForm = new ErrorForm(e.ToString(), uuid, analytics == Lemma.Main.Config.RecordAnalytics.On);
 #if ANALYTICS
 					if (main != null)
@@ -83,6 +90,7 @@ namespace Lemma
 					}
 #endif
 					System.Windows.Forms.Application.Run(errorForm);
+#endif
 				}
 #endif
 				finally


### PR DESCRIPTION
Only like 4 years late!

This makes the FNA version work correctly, at least on Windows. A Linux build would need the Wwise binaries, file path checking, the usual stuff.

Main changes:
- Remove XNA references in the project files
- Fix TODO items added from the initial FNA port commit
- Disable analytics, Forms

Possible items for the future:
- Portable adapter selection
- Portable error reporting system
- Re-enable analytics for an official build